### PR TITLE
Fix: Clean up gitignore and ignore bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,3 @@
-# Bootstrap
-app/bootstrap*
-
-# Symfony directories
 vendor/*
-*/logs/*
-*/cache/*
-web/uploads/*
-web/bundles/*
-
-# Configuration files
-app/config/parameters.ini
-app/config/parameters.yml
 composer.lock
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
+bin/*
 vendor/*
 composer.lock
-


### PR DESCRIPTION
This PR

* [x] removes unneeded entries from `.gitignore`
* [x] adds `bin` directory to `.gitignore`

:information_desk_person: When running `composer install`, the vendor binaries are installed there and I end up with untracked files.