### PR TITLE
Fix: Send builds to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 php:
   - 5.3
   - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ cache:
     - $HOME/.composer/cache
 
 install:
-  - composer install --prefer-dist --dev
+  - composer install --prefer-dist
 
 script: bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ php:
   - 5.6
   - hhvm
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 install:
-- composer install --prefer-source --dev
+  - composer install --prefer-dist --dev
 
 script: bin/phpunit


### PR DESCRIPTION
This PR

* [x] sends builds to container-based infrastructure on Travis
* [x] enables caching of dependencies as installed with Composer
* [x] removes the `--dev` option when installing dependencies, it's the default anyway

:information_desk_person: To really make use of caching, one should create a GitHub token and use it to authenticate with the GitHub API:

1. Acquire a GitHub authentication token (go to https://github.com/settings/tokens/new)
2. Install the `travis` command line tool (see https://github.com/travis-ci/travis.rb#installation)
3. Encrypt the GitHub authentication token

    ```
$ travis encrypt GITHUB_TOKEN=foobarbaz
    ```
4. Add the encrypted token to `.travis.yml`

    ```yml
    env:
      global:
        - secure: "..."
    ```
5. Use token to authenticate against GitHub API before installing dependencies

    ```yml
    before_install:  
      - composer config github-oauth.github.com $GITHUB_TOKEN
    ```