### PR TITLE
Fix: Remove bootstrap file which is never used

### DIFF
--- a/tests/Bitly/Tests/bootstrap.php
+++ b/tests/Bitly/Tests/bootstrap.php
@@ -1,8 +1,0 @@
-<?php
-
-$file = __DIR__.'/../vendor/autoload.php';
-if (!file_exists($file)) {
-    throw new RuntimeException('Install dependencies to run test suite. "php composer.phar install --dev"');
-}
-
-require_once $file;


### PR DESCRIPTION
This PR

* [x] removes a test bootstrapper which is never used